### PR TITLE
[PRMT-3415] 

### DIFF
--- a/src/services/jobs/ehr-deletion-job/__tests__/ehr-deletion-job.test.js
+++ b/src/services/jobs/ehr-deletion-job/__tests__/ehr-deletion-job.test.js
@@ -6,22 +6,23 @@ import { logInfo } from '../../../../middleware/logging';
 import { ehrDeletionJob } from '../ehr-deletion-job';
 import { getHealthRecords } from './test-utilities';
 import moment from 'moment/moment';
-import { now } from 'moment';
-import sinon from 'sinon';
 
 // Mocking
 jest.mock('../../../database/health-record-repository');
 jest.mock('../check-date-delete');
 jest.mock('../../../../middleware/logging');
 
+const flushPromises = async () => {
+  // utility function to wait for pending promises in background to complete first
+  return new Promise((resolve) => jest.requireActual('timers').setImmediate(resolve));
+};
+
 describe('ehr-deletion-job.js', () => {
   // ========================= COMMON PROPERTIES =========================
   const TWENTY_SECOND_TIMEOUT = 20000;
+  const TWO_MINUTES_TIMEOUT = 1000 * 60 * 2;
 
-  const clock = sinon.useFakeTimers({
-    now: now(),
-    shouldClearNativeTimers: true,
-  });
+  jest.useFakeTimers();
 
   const timeframes = {
     DAY: 1000 * 60 * 60 * 24,
@@ -40,7 +41,6 @@ describe('ehr-deletion-job.js', () => {
   afterEach(() => {
     ehrDeletionJob.stop();
     jest.resetAllMocks();
-    sinon.reset();
   });
 
   it(
@@ -49,7 +49,8 @@ describe('ehr-deletion-job.js', () => {
       // when
       findAllSoftDeletedHealthRecords.mockResolvedValueOnce([]);
 
-      await clock.tickAsync(timeframes.DAY);
+      jest.advanceTimersByTime(timeframes.DAY);
+      await flushPromises();
 
       // then
       expect(findAllSoftDeletedHealthRecords).toBeCalledTimes(1);
@@ -65,14 +66,15 @@ describe('ehr-deletion-job.js', () => {
       // when
       findAllSoftDeletedHealthRecords.mockResolvedValue([]);
 
-      await clock.tickAsync(timeframes.WEEK);
+      jest.advanceTimersByTime(timeframes.WEEK);
+      await flushPromises();
 
       // then
       expect(findAllSoftDeletedHealthRecords).toBeCalledTimes(7);
       expect(logInfo).toBeCalledTimes(14);
       expect(checkDateAndDelete).toBeCalledTimes(0);
     },
-    TWENTY_SECOND_TIMEOUT // this test takes longer than 5 seconds, setting it to 10 fixes it
+    TWO_MINUTES_TIMEOUT
   );
 
   it(
@@ -82,7 +84,8 @@ describe('ehr-deletion-job.js', () => {
       findAllSoftDeletedHealthRecords.mockResolvedValueOnce(healthRecord);
       checkDateAndDelete.mockResolvedValueOnce(undefined);
 
-      await clock.tickAsync(timeframes.DAY);
+      jest.advanceTimersByTime(timeframes.DAY);
+      await flushPromises();
 
       // then
       expect(findAllSoftDeletedHealthRecords).toBeCalledTimes(1);
@@ -98,7 +101,8 @@ describe('ehr-deletion-job.js', () => {
       // when
       findAllSoftDeletedHealthRecords.mockResolvedValueOnce([]);
 
-      await clock.tickAsync(timeframes.DAY);
+      jest.advanceTimersByTime(timeframes.DAY);
+      await flushPromises();
 
       // then
       expect(logInfo).toBeCalledTimes(2);

--- a/src/services/jobs/ehr-deletion-job/ehr-deletion-job.js
+++ b/src/services/jobs/ehr-deletion-job/ehr-deletion-job.js
@@ -4,14 +4,18 @@ import { checkDateAndDelete } from './check-date-delete';
 import { logInfo } from '../../../middleware/logging';
 import cron from 'node-cron';
 
-export const ehrDeletionJob = cron.schedule('00 03 * * *', async () => {
-  logInfo(`${loggerPrefix} Job triggered, preparing to delete health records.`);
+export const ehrDeletionJob = cron.schedule(
+  '00 03 * * *',
+  async () => {
+    logInfo(`${loggerPrefix} Job triggered, preparing to delete health records.`);
 
-  const records = await findAllSoftDeletedHealthRecords();
+    const records = await findAllSoftDeletedHealthRecords();
 
-  if (records.length > 0) {
-    await checkDateAndDelete(records);
-  } else {
-    logInfo(`${loggerPrefix} Could not find any health records that are marked for deletion.`);
-  }
-});
+    if (records.length > 0) {
+      await checkDateAndDelete(records);
+    } else {
+      logInfo(`${loggerPrefix} Could not find any health records that are marked for deletion.`);
+    }
+  },
+  { scheduled: false }
+);


### PR DESCRIPTION
Change ehr-deletion-job test to use jest fake timer instead of sinon timer 
(Attempt to fix the coverage test that runs in local but failed on gocd pipeline)